### PR TITLE
Adding .NET 8.0 to supported dotnet versions

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 func checkForDotNetVersion(source string) (debugPath string, version string) {
 
 	// https://learn.microsoft.com/en-us/dotnet/standard/frameworks
-	var dotnet_version_list = [35]string{"net7.0","net6.0","net5.0","netcoreapp3.1","netcoreapp3.0","netcoreapp2.2","netcoreapp2.1","netcoreapp2.0","netcoreapp1.1","netcoreapp1.0","netcoreapp1.0","netstandard2.1","netstandard2.0","netstandard1.6","netstandard1.5","netstandard1.4","netstandard1.3","netstandard1.2","netstandard1.1","netstandard1.0","net48","net472","net471","net47","net462","net461","net46","net452","net451","net45","net403","net40","net35","net20","net11"}
+	var dotnet_version_list = [36]string{"net8.0","net7.0","net6.0","net5.0","netcoreapp3.1","netcoreapp3.0","netcoreapp2.2","netcoreapp2.1","netcoreapp2.0","netcoreapp1.1","netcoreapp1.0","netcoreapp1.0","netstandard2.1","netstandard2.0","netstandard1.6","netstandard1.5","netstandard1.4","netstandard1.3","netstandard1.2","netstandard1.1","netstandard1.0","net48","net472","net471","net47","net462","net461","net46","net452","net451","net45","net403","net40","net35","net20","net11"}
 
 	err := filepath.WalkDir(source, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {


### PR DESCRIPTION
Func `checkForDotNetVersion` does not look for .NET 8.0 projects, which causes the application to miss the publish folder.

Adding `net8.0` to the `dotnet_version_list`